### PR TITLE
fix: rename list_components to tm_list_components to avoid collision

### DIFF
--- a/threat_modeling_mcp_server/server.py
+++ b/threat_modeling_mcp_server/server.py
@@ -77,7 +77,7 @@ SERVER_INSTRUCTIONS = """
     ### Architecture Analysis
     - `add_component`: Add a new component to the architecture
     - `update_component`: Update an existing component
-    - `list_components`: List all components
+    - `tm_list_components`: List all components
     - `delete_component`: Delete a component
     - `add_connection`: Add a new connection between components
     - `update_connection`: Update an existing connection

--- a/threat_modeling_mcp_server/tools/architecture_analyzer.py
+++ b/threat_modeling_mcp_server/tools/architecture_analyzer.py
@@ -615,7 +615,7 @@ This plan provides a structured approach for analyzing system architecture for s
 ### Step 1: Gather Architecture Data
 First, collect all architecture components using the following tools:
 
-1. **Get Components**: Use `list_components()` to retrieve all system components
+1. **Get Components**: Use `tm_list_components()` to retrieve all system components
 2. **Get Connections**: Use `list_connections()` to retrieve all component connections  
 3. **Get Data Stores**: Use `list_data_stores()` to retrieve all data storage elements
 
@@ -626,7 +626,7 @@ Use the following prompt structure with an LLM to analyze the architecture:
 You are a cybersecurity expert analyzing a system architecture for security concerns. 
 
 ARCHITECTURE DATA:
-[Insert the output from list_components(), list_connections(), and list_data_stores() here]
+[Insert the output from tm_list_components(), list_connections(), and list_data_stores() here]
 
 ANALYSIS INSTRUCTIONS:
 1. **Component Security Analysis**:
@@ -756,7 +756,7 @@ Combine the LLM analysis with AWS documentation validation to produce a comprehe
 
 ## Tools and Resources
 
-- **Architecture Tools**: list_components, list_connections, list_data_stores
+- **Architecture Tools**: tm_list_components, list_connections, list_data_stores
 - **AWS Documentation**: AWS Documentation MCP Server for validation
 - **Analysis Framework**: STRIDE, OWASP, NIST Cybersecurity Framework
 - **Compliance Standards**: SOC 2, ISO 27001, PCI DSS, GDPR (as applicable)
@@ -860,7 +860,7 @@ def register_tools(mcp):
         """
         return await update_component_impl(ctx, id, name, type, service_provider, specific_service, version, description, configuration)
 
-    @mcp.tool()
+    @mcp.tool(name="tm_list_components")
     async def list_components(
         ctx: Context,
         type: Optional[str] = Field(default=None, description="Optional type to filter components"),

--- a/threat_modeling_mcp_server/tools/trust_boundary_detector.py
+++ b/threat_modeling_mcp_server/tools/trust_boundary_detector.py
@@ -34,7 +34,7 @@ This plan provides a structured approach for detecting trust boundaries from arc
 ### Step 1: Gather Architecture Data
 First, collect all architecture information using the following tools:
 
-1. **Get Components**: Use `list_components()` to retrieve all system components
+1. **Get Components**: Use `tm_list_components()` to retrieve all system components
 2. **Get Connections**: Use `list_connections()` to retrieve all connections between components
 3. **Get Data Stores**: Use `list_data_stores()` to retrieve all data stores
 
@@ -45,7 +45,7 @@ Use the following prompt structure with an LLM to detect trust zones:
 You are a cybersecurity expert analyzing system architecture to detect trust zones for threat modeling.
 
 ARCHITECTURE DATA:
-[Insert the output from list_components(), list_connections(), and list_data_stores() here]
+[Insert the output from tm_list_components(), list_connections(), and list_data_stores() here]
 
 ANALYSIS INSTRUCTIONS:
 Analyze the architecture and identify logical trust zones based on:
@@ -301,7 +301,7 @@ Use the validation guidance and manual tools to refine the detection results as 
 
 ## Tools and Resources
 
-- **Architecture Tools**: list_components, list_connections, list_data_stores
+- **Architecture Tools**: tm_list_components, list_connections, list_data_stores
 - **Trust Boundary Tools**: add_trust_zone, add_crossing_point, add_trust_boundary
 - **AWS Documentation**: AWS Documentation MCP Server for validation
 - **Security Frameworks**: NIST Cybersecurity Framework, OWASP, industry standards


### PR DESCRIPTION
## Summary

Renames the `list_components` MCP tool to `tm_list_components` to resolve a tool name collision with the `meridian-mcp` server.

## Problem

ATC (Agent Tool Checker) finding **ATC-TMC004**: Tool `list_components` has an exact name collision with server `meridian-mcp`. Identical tool names across servers cause routing ambiguity and may lead to incorrect tool invocation by agents.

## Fix

Renamed using the `{NAMESPACE}_{VERB}_{RESOURCE}` pattern as recommended by ATC:
- `list_components` → `tm_list_components`

## Changes

- `server.py`: Updated instruction reference
- `tools/architecture_analyzer.py`: Added `name="tm_list_components"` to `@mcp.tool()` decorator, updated doc references
- `tools/trust_boundary_detector.py`: Updated doc references

## Testing

- Verified tool registration works with the new name
- All other tool references updated consistently