### PR TITLE
feat: add batch operation support to all CRUD tools

### DIFF
--- a/tests/test_batch_integration.py
+++ b/tests/test_batch_integration.py
@@ -1,0 +1,287 @@
+"""Integration test that simulates real MCP tool calls end-to-end.
+
+This script tests both single-item (backwards compat) and batch modes
+by calling the _impl functions through the batch_utils layer, exactly
+as the registered tools do internally.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock
+
+from threat_modeling_mcp_server.tools.architecture_analyzer import (
+    add_component_impl, update_component_impl, delete_component_impl,
+    list_components_impl, components, connections, data_stores, architecture,
+    add_connection_impl, add_data_store_impl
+)
+from threat_modeling_mcp_server.tools.assumption_manager import (
+    add_assumption_impl, update_assumption_impl, delete_assumption_impl,
+    assumptions
+)
+from threat_modeling_mcp_server.tools.threat_actor_analyzer import (
+    add_threat_actor_impl, delete_threat_actor_impl,
+    threat_actors, initialize_threat_actors
+)
+from threat_modeling_mcp_server.tools.threat_generator import (
+    add_threat_impl, update_threat_impl, delete_threat_impl,
+    add_mitigation_impl, delete_mitigation_impl,
+    threats, mitigations
+)
+from threat_modeling_mcp_server.tools.asset_flow_analyzer import (
+    add_asset_impl, delete_asset_impl, assets, flows
+)
+from threat_modeling_mcp_server.tools.trust_boundary_analyzer import (
+    add_trust_zone_impl, delete_trust_zone_impl,
+    initialize_trust_boundaries
+)
+import threat_modeling_mcp_server.tools.trust_boundary_analyzer as tba
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
+
+
+async def run_integration_tests():
+    ctx = AsyncMock()
+    passed = 0
+    failed = 0
+    
+    def check(test_name, condition, detail=""):
+        nonlocal passed, failed
+        if condition:
+            print(f"  ✅ {test_name}")
+            passed += 1
+        else:
+            print(f"  ❌ {test_name} — {detail}")
+            failed += 1
+
+    # Clear state
+    components.clear()
+    architecture.components = []
+    architecture.connections = []
+    architecture.data_stores = []
+    assumptions.clear()
+    threats.clear()
+    mitigations.clear()
+    assets.clear()
+    flows.clear()
+
+    # ============================================================
+    print("\n🔧 ARCHITECTURE: Components")
+    print("=" * 50)
+    
+    # Single item mode (backwards compat)
+    result = await batch_add(
+        ctx, None,
+        {"name": "API Gateway", "type": "Network"},
+        add_component_impl, "component"
+    )
+    check("Single add_component", "Component added with ID:" in result, result)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"name": "Lambda Function", "type": "Compute", "service_provider": "AWS", "specific_service": "Lambda"},
+            {"name": "DynamoDB Table", "type": "Storage", "service_provider": "AWS", "specific_service": "DynamoDB"},
+            {"name": "S3 Bucket", "type": "Storage", "service_provider": "AWS", "specific_service": "S3"},
+        ],
+        {},
+        add_component_impl, "component"
+    )
+    check("Batch add_component (3 items)", "Successfully added 3 component(s)" in result, result)
+    
+    # List to verify
+    result = await list_components_impl(ctx)
+    check("list_components shows all 4", "API Gateway" in result and "Lambda Function" in result and "S3 Bucket" in result, result[:200])
+    
+    # Batch update
+    result = await batch_update(
+        ctx,
+        [
+            {"id": "C001", "description": "Main entry point"},
+            {"id": "C002", "description": "Auth handler"},
+        ],
+        {},
+        update_component_impl, "component"
+    )
+    check("Batch update_component (2 items)", "Successfully updated 2 component(s)" in result, result)
+    
+    # Single update (backwards compat)
+    result = await batch_update(
+        ctx, None,
+        {"id": "C003", "description": "Primary data store"},
+        update_component_impl, "component"
+    )
+    check("Single update_component", "updated successfully" in result, result)
+    
+    # Batch delete
+    result = await batch_delete(ctx, ["C003", "C004"], None, delete_component_impl, "component")
+    check("Batch delete_component (2 items)", "Successfully deleted 2 component(s)" in result, result)
+    
+    # Single delete (backwards compat)
+    result = await batch_delete(ctx, None, "C002", delete_component_impl, "component")
+    check("Single delete_component", "deleted successfully" in result, result)
+
+    # ============================================================
+    print("\n🔧 ASSUMPTIONS")
+    print("=" * 50)
+    
+    # Single mode
+    result = await batch_add(
+        ctx, None,
+        {"description": "Network is internal", "category": "Network", "impact": "Low risk", "rationale": "VPC only"},
+        add_assumption_impl, "assumption"
+    )
+    check("Single add_assumption", "Assumption added with ID:" in result, result)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"description": "All data encrypted at rest", "category": "Data", "impact": "Reduces breach impact", "rationale": "AWS KMS"},
+            {"description": "MFA enforced", "category": "Authentication", "impact": "Prevents credential theft", "rationale": "Company policy"},
+        ],
+        {},
+        add_assumption_impl, "assumption"
+    )
+    check("Batch add_assumption (2 items)", "Successfully added 2 assumption(s)" in result, result)
+
+    # ============================================================
+    print("\n🔧 THREATS")
+    print("=" * 50)
+    
+    # Single mode
+    result = await batch_add(
+        ctx, None,
+        {"threat_source": "external attacker", "prerequisites": "network access", "threat_action": "SQL injection", "threat_impact": "data breach"},
+        add_threat_impl, "threat"
+    )
+    check("Single add_threat", "Threat added with ID:" in result, result)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"threat_source": "insider", "prerequisites": "valid credentials", "threat_action": "data exfiltration", "threat_impact": "IP theft", "severity": "High"},
+            {"threat_source": "script kiddie", "prerequisites": "public endpoint", "threat_action": "DDoS attack", "threat_impact": "service unavailability", "severity": "Medium"},
+            {"threat_source": "nation state", "prerequisites": "supply chain access", "threat_action": "backdoor installation", "threat_impact": "persistent access", "severity": "Critical"},
+        ],
+        {},
+        add_threat_impl, "threat"
+    )
+    check("Batch add_threat (3 items)", "Successfully added 3 threat(s)" in result, result)
+
+    # ============================================================
+    print("\n🔧 MITIGATIONS")
+    print("=" * 50)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"content": "Implement WAF rules for SQL injection"},
+            {"content": "Enable DDoS protection via AWS Shield"},
+            {"content": "Implement supply chain security scanning"},
+        ],
+        {},
+        add_mitigation_impl, "mitigation"
+    )
+    check("Batch add_mitigation (3 items)", "Successfully added 3 mitigation(s)" in result, result)
+
+    # ============================================================
+    print("\n🔧 ASSETS")
+    print("=" * 50)
+    
+    # Single mode
+    result = await batch_add(
+        ctx, None,
+        {"name": "Customer PII", "type": "Data", "classification": "Confidential"},
+        add_asset_impl, "asset"
+    )
+    check("Single add_asset", "Asset added with ID:" in result, result)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"name": "API Keys", "type": "Credential", "classification": "Restricted", "sensitivity": 5},
+            {"name": "Audit Logs", "type": "Data", "classification": "Internal", "criticality": 4},
+        ],
+        {},
+        add_asset_impl, "asset"
+    )
+    check("Batch add_asset (2 items)", "Successfully added 2 asset(s)" in result, result)
+
+    # ============================================================
+    print("\n🔧 TRUST ZONES")
+    print("=" * 50)
+    
+    tba.initialize_trust_boundaries()
+    initial_tz_count = len(tba.trust_zones)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"name": "Public Internet", "trust_level": "Untrusted"},
+            {"name": "DMZ", "trust_level": "Low"},
+            {"name": "Internal Network", "trust_level": "High"},
+        ],
+        {},
+        add_trust_zone_impl, "trust zone"
+    )
+    check("Batch add_trust_zone (3 items)", "Successfully added 3 trust zone(s)" in result, result)
+    check("Trust zones count increased by 3", len(tba.trust_zones) == initial_tz_count + 3, f"expected {initial_tz_count + 3}, got {len(tba.trust_zones)}")
+
+    # ============================================================
+    print("\n🔧 THREAT ACTORS")
+    print("=" * 50)
+    
+    initialize_threat_actors()
+    initial_ta_count = len(threat_actors)
+    
+    # Batch mode
+    result = await batch_add(
+        ctx,
+        [
+            {"name": "Hacktivist Group", "type": "Hacktivist", "capability_level": "Medium", "motivations": ["Political"], "resources": "Moderate"},
+            {"name": "Competitor", "type": "Competitor", "capability_level": "High", "motivations": ["Financial", "Espionage"], "resources": "Extensive"},
+        ],
+        {},
+        add_threat_actor_impl, "threat actor"
+    )
+    check("Batch add_threat_actor (2 items)", "Successfully added 2 threat actor(s)" in result, result)
+
+    # ============================================================
+    print("\n🔧 ERROR HANDLING")
+    print("=" * 50)
+    
+    # Batch with one invalid item
+    result = await batch_add(
+        ctx,
+        [
+            {"name": "Good Component", "type": "Compute"},
+            {"name": "Bad Component", "type": "TotallyInvalidType"},
+        ],
+        {},
+        add_component_impl, "component"
+    )
+    check("Batch with invalid item (partial success)", "Successfully added 1" in result and "Failed to add 1" in result, result)
+    
+    # Empty batch
+    result = await batch_add(ctx, [], {}, add_component_impl, "component")
+    check("Empty batch returns message", "No components provided" in result, result)
+    
+    # Batch delete with nonexistent IDs
+    result = await batch_delete(ctx, ["NONEXISTENT1", "NONEXISTENT2"], None, delete_component_impl, "component")
+    check("Batch delete nonexistent (graceful)", "not found" in result.lower(), result)
+
+    # ============================================================
+    print("\n" + "=" * 50)
+    print(f"📊 RESULTS: {passed} passed, {failed} failed, {passed + failed} total")
+    print("=" * 50)
+    
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = asyncio.run(run_integration_tests())
+    sys.exit(0 if success else 1)

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -1,0 +1,283 @@
+"""Tests for batch operation support across all CRUD tools."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from threat_modeling_mcp_server.tools.architecture_analyzer import (
+    add_component_impl, update_component_impl, delete_component_impl,
+    components, architecture
+)
+from threat_modeling_mcp_server.tools.assumption_manager import (
+    add_assumption_impl, update_assumption_impl, delete_assumption_impl,
+    assumptions
+)
+from threat_modeling_mcp_server.tools.threat_actor_analyzer import (
+    add_threat_actor_impl, update_threat_actor_impl, delete_threat_actor_impl,
+    threat_actors, initialize_threat_actors
+)
+from threat_modeling_mcp_server.tools.threat_generator import (
+    add_threat_impl, update_threat_impl, delete_threat_impl,
+    add_mitigation_impl, update_mitigation_impl, delete_mitigation_impl,
+    threats, mitigations
+)
+from threat_modeling_mcp_server.tools.asset_flow_analyzer import (
+    add_asset_impl, update_asset_impl, delete_asset_impl,
+    add_flow_impl, update_flow_impl, delete_flow_impl,
+    assets, flows
+)
+from threat_modeling_mcp_server.tools.trust_boundary_analyzer import (
+    add_trust_zone_impl, update_trust_zone_impl, delete_trust_zone_impl,
+    add_crossing_point_impl, delete_crossing_point_impl,
+    add_trust_boundary_impl, delete_trust_boundary_impl,
+    trust_zones, crossing_points, trust_boundaries,
+    initialize_trust_boundaries
+)
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
+
+
+@pytest.fixture
+def ctx():
+    """Create a mock context."""
+    return AsyncMock()
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    """Clear global state before each test."""
+    components.clear()
+    architecture.components = []
+    architecture.connections = []
+    architecture.data_stores = []
+    assumptions.clear()
+    threats.clear()
+    mitigations.clear()
+    assets.clear()
+    flows.clear()
+    trust_zones.clear()
+    crossing_points.clear()
+    trust_boundaries.clear()
+    yield
+
+
+# ============================================================
+# Architecture: Components
+# ============================================================
+
+class TestBatchAddComponents:
+    async def test_single_item_mode(self, ctx):
+        """Single item mode still works (backwards compat)."""
+        result = await batch_add(
+            ctx, None,
+            {"name": "Web Server", "type": "Compute"},
+            add_component_impl, "component"
+        )
+        assert "Component added with ID:" in result
+        assert len(components) == 1
+
+    async def test_batch_mode(self, ctx):
+        """Batch mode adds multiple components."""
+        items = [
+            {"name": "Web Server", "type": "Compute"},
+            {"name": "Database", "type": "Storage"},
+            {"name": "Load Balancer", "type": "Network"},
+        ]
+        result = await batch_add(ctx, items, {}, add_component_impl, "component")
+        assert "Successfully added 3 component(s)" in result
+        assert len(components) == 3
+
+    async def test_batch_empty_list(self, ctx):
+        """Empty batch returns appropriate message."""
+        result = await batch_add(ctx, [], {}, add_component_impl, "component")
+        assert "No components provided in batch" in result
+
+    async def test_batch_with_optional_fields(self, ctx):
+        """Batch items can include optional fields."""
+        items = [
+            {"name": "Lambda", "type": "Compute", "service_provider": "AWS", "specific_service": "Lambda"},
+            {"name": "S3 Bucket", "type": "Storage", "service_provider": "AWS", "description": "Main storage"},
+        ]
+        result = await batch_add(ctx, items, {}, add_component_impl, "component")
+        assert "Successfully added 2 component(s)" in result
+        # Verify optional fields were set
+        comp_list = list(components.values())
+        assert comp_list[0].specific_service == "Lambda"
+        assert comp_list[1].description == "Main storage"
+
+    async def test_batch_with_invalid_item(self, ctx):
+        """Batch handles errors gracefully for individual items."""
+        items = [
+            {"name": "Web Server", "type": "Compute"},
+            {"name": "Bad Component", "type": "InvalidType"},  # Invalid enum
+        ]
+        result = await batch_add(ctx, items, {}, add_component_impl, "component")
+        assert "Successfully added 1 component(s)" in result
+        assert "Failed to add 1 component(s)" in result
+
+
+class TestBatchUpdateComponents:
+    async def test_single_item_mode(self, ctx):
+        """Single item update still works."""
+        await add_component_impl(ctx, "Web Server", "Compute")
+        comp_id = list(components.keys())[0]
+        result = await batch_update(
+            ctx, None,
+            {"id": comp_id, "name": "Updated Server"},
+            update_component_impl, "component"
+        )
+        assert "updated successfully" in result
+        assert components[comp_id].name == "Updated Server"
+
+    async def test_batch_mode(self, ctx):
+        """Batch update modifies multiple components."""
+        await add_component_impl(ctx, "Server A", "Compute")
+        await add_component_impl(ctx, "Server B", "Compute")
+        ids = list(components.keys())
+        
+        items = [
+            {"id": ids[0], "name": "Updated A"},
+            {"id": ids[1], "name": "Updated B"},
+        ]
+        result = await batch_update(ctx, items, {}, update_component_impl, "component")
+        assert "Successfully updated 2 component(s)" in result
+        assert components[ids[0]].name == "Updated A"
+        assert components[ids[1]].name == "Updated B"
+
+
+class TestBatchDeleteComponents:
+    async def test_single_item_mode(self, ctx):
+        """Single item delete still works."""
+        await add_component_impl(ctx, "Web Server", "Compute")
+        comp_id = list(components.keys())[0]
+        result = await batch_delete(ctx, None, comp_id, delete_component_impl, "component")
+        assert "deleted successfully" in result
+        assert len(components) == 0
+
+    async def test_batch_mode(self, ctx):
+        """Batch delete removes multiple components."""
+        await add_component_impl(ctx, "Server A", "Compute")
+        await add_component_impl(ctx, "Server B", "Compute")
+        await add_component_impl(ctx, "Server C", "Compute")
+        ids = list(components.keys())
+        
+        result = await batch_delete(ctx, [ids[0], ids[2]], None, delete_component_impl, "component")
+        assert "Successfully deleted 2 component(s)" in result
+        assert len(components) == 1
+        assert ids[1] in components
+
+    async def test_batch_with_nonexistent_id(self, ctx):
+        """Batch delete handles missing IDs gracefully."""
+        await add_component_impl(ctx, "Server A", "Compute")
+        comp_id = list(components.keys())[0]
+        
+        result = await batch_delete(ctx, [comp_id, "NONEXISTENT"], None, delete_component_impl, "component")
+        # The first should succeed, second should report "not found" (not an exception)
+        assert "deleted successfully" in result
+
+
+# ============================================================
+# Assumptions
+# ============================================================
+
+class TestBatchAssumptions:
+    async def test_batch_add(self, ctx):
+        items = [
+            {"description": "Network is secure", "category": "Network", "impact": "Low", "rationale": "Internal only"},
+            {"description": "Auth is MFA", "category": "Authentication", "impact": "Medium", "rationale": "Policy"},
+        ]
+        result = await batch_add(ctx, items, {}, add_assumption_impl, "assumption")
+        assert "Successfully added 2 assumption(s)" in result
+        assert len(assumptions) == 2
+
+    async def test_batch_delete(self, ctx):
+        await add_assumption_impl(ctx, "Assumption 1", "Network", "Low", "Reason")
+        await add_assumption_impl(ctx, "Assumption 2", "Auth", "High", "Reason")
+        ids = list(assumptions.keys())
+        result = await batch_delete(ctx, ids, None, delete_assumption_impl, "assumption")
+        assert "Successfully deleted 2 assumption(s)" in result
+        assert len(assumptions) == 0
+
+
+# ============================================================
+# Threats and Mitigations
+# ============================================================
+
+class TestBatchThreats:
+    async def test_batch_add_threats(self, ctx):
+        items = [
+            {"threat_source": "attacker", "prerequisites": "network access",
+             "threat_action": "intercept data", "threat_impact": "data breach"},
+            {"threat_source": "insider", "prerequisites": "valid credentials",
+             "threat_action": "exfiltrate data", "threat_impact": "IP theft"},
+        ]
+        result = await batch_add(ctx, items, {}, add_threat_impl, "threat")
+        assert "Successfully added 2 threat(s)" in result
+        assert len(threats) == 2
+
+    async def test_batch_delete_threats(self, ctx):
+        await add_threat_impl(ctx, "src", "pre", "action", "impact")
+        await add_threat_impl(ctx, "src2", "pre2", "action2", "impact2")
+        ids = list(threats.keys())
+        result = await batch_delete(ctx, ids, None, delete_threat_impl, "threat")
+        assert "Successfully deleted 2 threat(s)" in result
+
+    async def test_batch_add_mitigations(self, ctx):
+        items = [
+            {"content": "Implement TLS"},
+            {"content": "Add WAF", "type": "Preventive"},
+        ]
+        result = await batch_add(ctx, items, {}, add_mitigation_impl, "mitigation")
+        assert "Successfully added 2 mitigation(s)" in result
+        assert len(mitigations) == 2
+
+
+# ============================================================
+# Assets and Flows
+# ============================================================
+
+class TestBatchAssets:
+    async def test_batch_add_assets(self, ctx):
+        items = [
+            {"name": "User PII", "type": "Data", "classification": "Confidential"},
+            {"name": "API Key", "type": "Credential", "classification": "Restricted"},
+        ]
+        result = await batch_add(ctx, items, {}, add_asset_impl, "asset")
+        assert "Successfully added 2 asset(s)" in result
+        assert len(assets) == 2
+
+    async def test_batch_delete_assets(self, ctx):
+        await add_asset_impl(ctx, "Asset 1", "Data", "Public")
+        await add_asset_impl(ctx, "Asset 2", "Data", "Internal")
+        ids = list(assets.keys())
+        result = await batch_delete(ctx, ids, None, delete_asset_impl, "asset")
+        assert "Successfully deleted 2 asset(s)" in result
+
+
+# ============================================================
+# Trust Zones
+# ============================================================
+
+class TestBatchTrustZones:
+    async def test_batch_add_trust_zones(self, ctx):
+        import threat_modeling_mcp_server.tools.trust_boundary_analyzer as tba
+        # initialize so the global is set
+        tba.initialize_trust_boundaries()
+        initial_count = len(tba.trust_zones)
+        items = [
+            {"name": "Public Zone", "trust_level": "Untrusted"},
+            {"name": "Internal Zone", "trust_level": "High"},
+        ]
+        result = await batch_add(ctx, items, {}, add_trust_zone_impl, "trust zone")
+        assert "Successfully added 2 trust zone(s)" in result
+        assert len(tba.trust_zones) == initial_count + 2
+
+    async def test_batch_delete_trust_zones(self, ctx):
+        import threat_modeling_mcp_server.tools.trust_boundary_analyzer as tba
+        tba.initialize_trust_boundaries()
+        # Add two fresh zones we control
+        await add_trust_zone_impl(ctx, "Zone A", "Untrusted")
+        await add_trust_zone_impl(ctx, "Zone B", "High")
+        # Get the last two IDs added
+        all_ids = list(tba.trust_zones.keys())
+        new_ids = all_ids[-2:]
+        result = await batch_delete(ctx, new_ids, None, delete_trust_zone_impl, "trust zone")
+        assert "Successfully deleted 2 trust zone(s)" in result

--- a/threat_modeling_mcp_server/tools/architecture_analyzer.py
+++ b/threat_modeling_mcp_server/tools/architecture_analyzer.py
@@ -11,6 +11,7 @@ from threat_modeling_mcp_server.models.architecture_models import (
     ComponentType, ServiceProvider, Protocol, DataStoreType,
     DataClassification, BackupFrequency, AWSService
 )
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # Global state
@@ -801,37 +802,47 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_component(
         ctx: Context,
-        name: str = Field(description="Name of the component"),
-        type: str = Field(description="Type of the component (e.g., 'Compute', 'Storage', 'Network')"),
+        name: str = Field(default=None, description="Name of the component (required for single item mode)"),
+        type: str = Field(default=None, description="Type of the component (e.g., 'Compute', 'Storage', 'Network') (required for single item mode)"),
         service_provider: Optional[str] = Field(default=None, description="Provider of the service (e.g., 'AWS', 'Azure', 'GCP')"),
         specific_service: Optional[str] = Field(default=None, description="Specific service name (e.g., 'EC2', 'S3', 'Lambda')"),
         version: Optional[str] = Field(default=None, description="Version of the component"),
         description: Optional[str] = Field(default=None, description="Description of the component"),
         configuration: Optional[Dict[str, Any]] = Field(default=None, description="Configuration details of the component"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of components to add in batch. Each dict should contain 'name', 'type', and optionally 'service_provider', 'specific_service', 'version', 'description', 'configuration'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new component to the architecture.
+        """Add a new component to the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new component to the system architecture.
+        This tool adds one or more components to the system architecture.
+        For single item: provide name, type, and optional fields directly.
+        For batch: provide a list of component dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the component
-            type: Type of the component (e.g., 'Compute', 'Storage', 'Network')
+            name: Name of the component (required for single item mode)
+            type: Type of the component (required for single item mode)
             service_provider: Provider of the service (e.g., 'AWS', 'Azure', 'GCP')
             specific_service: Specific service name (e.g., 'EC2', 'S3', 'Lambda')
             version: Version of the component
             description: Description of the component
             configuration: Configuration details of the component
+            items: Optional list of component dicts for batch operation
 
         Returns:
-            A confirmation message with the component ID
+            A confirmation message with the component ID(s)
         """
-        return await add_component_impl(ctx, name, type, service_provider, specific_service, version, description, configuration)
+        return await batch_add(
+            ctx, items,
+            {"name": name, "type": type, "service_provider": service_provider,
+             "specific_service": specific_service, "version": version,
+             "description": description, "configuration": configuration},
+            add_component_impl, "component"
+        )
 
     @mcp.tool()
     async def update_component(
         ctx: Context,
-        id: str = Field(description="ID of the component to update"),
+        id: str = Field(default=None, description="ID of the component to update (required for single item mode)"),
         name: Optional[str] = Field(default=None, description="New name of the component"),
         type: Optional[str] = Field(default=None, description="New type of the component"),
         service_provider: Optional[str] = Field(default=None, description="New provider of the service"),
@@ -839,14 +850,17 @@ def register_tools(mcp):
         version: Optional[str] = Field(default=None, description="New version of the component"),
         description: Optional[str] = Field(default=None, description="New description of the component"),
         configuration: Optional[Dict[str, Any]] = Field(default=None, description="New configuration details of the component"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of components to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing component in the architecture.
+        """Update an existing component in the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing component in the system architecture.
+        This tool updates one or more existing components in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of component dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the component to update
+            id: ID of the component to update (required for single item mode)
             name: New name of the component
             type: New type of the component
             service_provider: New provider of the service
@@ -854,11 +868,18 @@ def register_tools(mcp):
             version: New version of the component
             description: New description of the component
             configuration: New configuration details of the component
+            items: Optional list of component dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_component_impl(ctx, id, name, type, service_provider, specific_service, version, description, configuration)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "type": type, "service_provider": service_provider,
+             "specific_service": specific_service, "version": version,
+             "description": description, "configuration": configuration},
+            update_component_impl, "component"
+        )
 
     @mcp.tool()
     async def list_components(
@@ -881,78 +902,102 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_component(
         ctx: Context,
-        id: str = Field(description="ID of the component to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the component to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of component IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a component from the architecture.
+        """Delete a component from the architecture. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a component from the system architecture.
+        This tool deletes one or more components from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the component to delete
+            id: ID of the component to delete (required for single item mode)
+            ids: Optional list of component IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_component_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_component_impl, "component")
     
     @mcp.tool()
     async def add_connection(
         ctx: Context,
-        source_id: str = Field(description="ID of the source component"),
-        destination_id: str = Field(description="ID of the destination component"),
+        source_id: str = Field(default=None, description="ID of the source component (required for single item mode)"),
+        destination_id: str = Field(default=None, description="ID of the destination component (required for single item mode)"),
         protocol: Optional[str] = Field(default=None, description="Protocol used for the connection (e.g., 'HTTP', 'HTTPS', 'TCP')"),
         port: Optional[int] = Field(default=None, description="Port used for the connection"),
         encryption: bool = Field(default=False, description="Whether the connection is encrypted"),
         description: Optional[str] = Field(default=None, description="Description of the connection"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of connections to add in batch. Each dict should contain 'source_id', 'destination_id', and optionally 'protocol', 'port', 'encryption', 'description'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new connection to the architecture.
+        """Add a new connection to the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new connection between two components in the system architecture.
+        This tool adds one or more connections between components in the system architecture.
+        For single item: provide source_id, destination_id, and optional fields directly.
+        For batch: provide a list of connection dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            source_id: ID of the source component
-            destination_id: ID of the destination component
+            source_id: ID of the source component (required for single item mode)
+            destination_id: ID of the destination component (required for single item mode)
             protocol: Protocol used for the connection (e.g., 'HTTP', 'HTTPS', 'TCP')
             port: Port used for the connection
             encryption: Whether the connection is encrypted
             description: Description of the connection
+            items: Optional list of connection dicts for batch operation
 
         Returns:
-            A confirmation message with the connection ID
+            A confirmation message with the connection ID(s)
         """
-        return await add_connection_impl(ctx, source_id, destination_id, protocol, port, encryption, description)
+        return await batch_add(
+            ctx, items,
+            {"source_id": source_id, "destination_id": destination_id,
+             "protocol": protocol, "port": port, "encryption": encryption,
+             "description": description},
+            add_connection_impl, "connection"
+        )
 
     @mcp.tool()
     async def update_connection(
         ctx: Context,
-        id: str = Field(description="ID of the connection to update"),
+        id: str = Field(default=None, description="ID of the connection to update (required for single item mode)"),
         source_id: Optional[str] = Field(default=None, description="New ID of the source component"),
         destination_id: Optional[str] = Field(default=None, description="New ID of the destination component"),
         protocol: Optional[str] = Field(default=None, description="New protocol used for the connection"),
         port: Optional[int] = Field(default=None, description="New port used for the connection"),
         encryption: Optional[bool] = Field(default=None, description="New encryption status"),
         description: Optional[str] = Field(default=None, description="New description of the connection"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of connections to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing connection in the architecture.
+        """Update an existing connection in the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing connection in the system architecture.
+        This tool updates one or more existing connections in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of connection dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the connection to update
+            id: ID of the connection to update (required for single item mode)
             source_id: New ID of the source component
             destination_id: New ID of the destination component
             protocol: New protocol used for the connection
             port: New port used for the connection
             encryption: New encryption status
             description: New description of the connection
+            items: Optional list of connection dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_connection_impl(ctx, id, source_id, destination_id, protocol, port, encryption, description)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "source_id": source_id, "destination_id": destination_id,
+             "protocol": protocol, "port": port, "encryption": encryption,
+             "description": description},
+            update_connection_impl, "connection"
+        )
 
     @mcp.tool()
     async def list_connections(
@@ -975,78 +1020,102 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_connection(
         ctx: Context,
-        id: str = Field(description="ID of the connection to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the connection to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of connection IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a connection from the architecture.
+        """Delete a connection from the architecture. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a connection from the system architecture.
+        This tool deletes one or more connections from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the connection to delete
+            id: ID of the connection to delete (required for single item mode)
+            ids: Optional list of connection IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_connection_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_connection_impl, "connection")
 
     @mcp.tool()
     async def add_data_store(
         ctx: Context,
-        name: str = Field(description="Name of the data store"),
-        type: str = Field(description="Type of the data store (e.g., 'Relational', 'NoSQL', 'Object Storage')"),
-        classification: str = Field(description="Classification of the data (e.g., 'Public', 'Internal', 'Confidential')"),
+        name: str = Field(default=None, description="Name of the data store (required for single item mode)"),
+        type: str = Field(default=None, description="Type of the data store (e.g., 'Relational', 'NoSQL', 'Object Storage') (required for single item mode)"),
+        classification: str = Field(default=None, description="Classification of the data (e.g., 'Public', 'Internal', 'Confidential') (required for single item mode)"),
         encryption_at_rest: bool = Field(default=False, description="Whether the data is encrypted at rest"),
         backup_frequency: Optional[str] = Field(default=None, description="Frequency of backups (e.g., 'Hourly', 'Daily', 'Weekly')"),
         description: Optional[str] = Field(default=None, description="Description of the data store"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of data stores to add in batch. Each dict should contain 'name', 'type', 'classification', and optionally 'encryption_at_rest', 'backup_frequency', 'description'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new data store to the architecture.
+        """Add a new data store to the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new data store to the system architecture.
+        This tool adds one or more data stores to the system architecture.
+        For single item: provide name, type, classification, and optional fields directly.
+        For batch: provide a list of data store dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the data store
-            type: Type of the data store (e.g., 'Relational', 'NoSQL', 'Object Storage')
-            classification: Classification of the data (e.g., 'Public', 'Internal', 'Confidential')
+            name: Name of the data store (required for single item mode)
+            type: Type of the data store (required for single item mode)
+            classification: Classification of the data (required for single item mode)
             encryption_at_rest: Whether the data is encrypted at rest
             backup_frequency: Frequency of backups (e.g., 'Hourly', 'Daily', 'Weekly')
             description: Description of the data store
+            items: Optional list of data store dicts for batch operation
 
         Returns:
-            A confirmation message with the data store ID
+            A confirmation message with the data store ID(s)
         """
-        return await add_data_store_impl(ctx, name, type, classification, encryption_at_rest, backup_frequency, description)
+        return await batch_add(
+            ctx, items,
+            {"name": name, "type": type, "classification": classification,
+             "encryption_at_rest": encryption_at_rest, "backup_frequency": backup_frequency,
+             "description": description},
+            add_data_store_impl, "data store"
+        )
 
     @mcp.tool()
     async def update_data_store(
         ctx: Context,
-        id: str = Field(description="ID of the data store to update"),
+        id: str = Field(default=None, description="ID of the data store to update (required for single item mode)"),
         name: Optional[str] = Field(default=None, description="New name of the data store"),
         type: Optional[str] = Field(default=None, description="New type of the data store"),
         classification: Optional[str] = Field(default=None, description="New classification of the data"),
         encryption_at_rest: Optional[bool] = Field(default=None, description="New encryption status"),
         backup_frequency: Optional[str] = Field(default=None, description="New frequency of backups"),
         description: Optional[str] = Field(default=None, description="New description of the data store"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of data stores to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing data store in the architecture.
+        """Update an existing data store in the architecture. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing data store in the system architecture.
+        This tool updates one or more existing data stores in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of data store dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the data store to update
+            id: ID of the data store to update (required for single item mode)
             name: New name of the data store
             type: New type of the data store
             classification: New classification of the data
             encryption_at_rest: New encryption status
             backup_frequency: New frequency of backups
             description: New description of the data store
+            items: Optional list of data store dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_data_store_impl(ctx, id, name, type, classification, encryption_at_rest, backup_frequency, description)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "type": type, "classification": classification,
+             "encryption_at_rest": encryption_at_rest, "backup_frequency": backup_frequency,
+             "description": description},
+            update_data_store_impl, "data store"
+        )
 
     @mcp.tool()
     async def list_data_stores(
@@ -1069,20 +1138,24 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_data_store(
         ctx: Context,
-        id: str = Field(description="ID of the data store to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the data store to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of data store IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a data store from the architecture.
+        """Delete a data store from the architecture. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a data store from the system architecture.
+        This tool deletes one or more data stores from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the data store to delete
+            id: ID of the data store to delete (required for single item mode)
+            ids: Optional list of data store IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_data_store_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_data_store_impl, "data store")
 
     @mcp.tool()
     async def get_architecture_analysis_plan(

--- a/threat_modeling_mcp_server/tools/asset_flow_analyzer.py
+++ b/threat_modeling_mcp_server/tools/asset_flow_analyzer.py
@@ -9,6 +9,7 @@ from threat_modeling_mcp_server.models.asset_flow_models import (
     LifecycleState, TransformationType, ControlType, AssetFlowLibrary
 )
 from threat_modeling_mcp_server.models.architecture_models import Component, Connection
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # Global dictionaries to store assets and flows
@@ -895,44 +896,52 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_asset(
         ctx: Context,
-        name: str,
-        type: str,
-        classification: str,
+        name: str = None,
+        type: str = None,
+        classification: str = None,
         lifecycle_state: Optional[str] = None,
         description: Optional[str] = None,
         owner: Optional[str] = None,
         sensitivity: Optional[int] = None,
         criticality: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Add a new asset to the system.
+        """Add a new asset to the system. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new asset to the system with the specified properties.
+        This tool adds one or more assets to the system.
+        For single item: provide name, type, classification, and optional fields directly.
+        For batch: provide a list of asset dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the asset
-            type: Type of the asset (e.g., 'Data', 'Credential', 'Process')
-            classification: Classification of the asset (e.g., 'Public', 'Confidential')
+            name: Name of the asset (required for single item mode)
+            type: Type of the asset (e.g., 'Data', 'Credential', 'Process') (required for single item mode)
+            classification: Classification of the asset (e.g., 'Public', 'Confidential') (required for single item mode)
             lifecycle_state: Current lifecycle state of the asset
             description: Description of the asset
             owner: Owner of the asset
             sensitivity: Sensitivity level of the asset (1-5)
             criticality: Criticality level of the asset (1-5)
             metadata: Additional metadata for the asset
+            items: Optional list of asset dicts for batch operation
 
         Returns:
-            A confirmation message with the asset ID
+            A confirmation message with the asset ID(s)
         """
-        return await add_asset_impl(
-            ctx, name, type, classification, lifecycle_state, description,
-            owner, sensitivity, criticality, metadata
+        return await batch_add(
+            ctx, items,
+            {"name": name, "type": type, "classification": classification,
+             "lifecycle_state": lifecycle_state, "description": description,
+             "owner": owner, "sensitivity": sensitivity, "criticality": criticality,
+             "metadata": metadata},
+            add_asset_impl, "asset"
         )
     
     @mcp.tool()
     async def update_asset(
         ctx: Context,
-        id: str,
+        id: str = None,
         name: Optional[str] = None,
         type: Optional[str] = None,
         classification: Optional[str] = None,
@@ -942,14 +951,17 @@ def register_tools(mcp):
         sensitivity: Optional[int] = None,
         criticality: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Update an existing asset.
+        """Update an existing asset. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing asset in the system with the specified properties.
+        This tool updates one or more existing assets in the system.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of asset dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the asset to update
+            id: ID of the asset to update (required for single item mode)
             name: New name of the asset
             type: New type of the asset
             classification: New classification of the asset
@@ -959,13 +971,18 @@ def register_tools(mcp):
             sensitivity: New sensitivity level of the asset
             criticality: New criticality level of the asset
             metadata: New metadata for the asset
+            items: Optional list of asset dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_asset_impl(
-            ctx, id, name, type, classification, lifecycle_state,
-            description, owner, sensitivity, criticality, metadata
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "type": type, "classification": classification,
+             "lifecycle_state": lifecycle_state, "description": description,
+             "owner": owner, "sensitivity": sensitivity, "criticality": criticality,
+             "metadata": metadata},
+            update_asset_impl, "asset"
         )
     
     @mcp.tool()
@@ -1009,27 +1026,31 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_asset(
         ctx: Context,
-        id: str,
+        id: Optional[str] = None,
+        ids: Optional[List[str]] = None,
     ) -> str:
-        """Delete an asset from the system.
+        """Delete an asset from the system. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes an asset from the system. The asset cannot be deleted if it is used in any flows.
+        This tool deletes one or more assets from the system. Assets cannot be deleted if used in any flows.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the asset to delete
+            id: ID of the asset to delete (required for single item mode)
+            ids: Optional list of asset IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_asset_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_asset_impl, "asset")
     
     @mcp.tool()
     async def add_flow(
         ctx: Context,
-        asset_id: str,
-        source_id: str,
-        destination_id: str,
+        asset_id: str = None,
+        source_id: str = None,
+        destination_id: str = None,
         transformation_type: Optional[str] = None,
         controls: Optional[List[str]] = None,
         description: Optional[str] = None,
@@ -1039,16 +1060,19 @@ def register_tools(mcp):
         authorized: bool = False,
         validated: bool = False,
         risk_level: Optional[int] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Add a new asset flow to the system.
+        """Add a new asset flow to the system. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new asset flow to the system with the specified properties.
+        This tool adds one or more asset flows to the system.
+        For single item: provide asset_id, source_id, destination_id, and optional fields directly.
+        For batch: provide a list of flow dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            asset_id: ID of the asset being transferred
-            source_id: ID of the source component or trust zone
-            destination_id: ID of the destination component or trust zone
+            asset_id: ID of the asset being transferred (required for single item mode)
+            source_id: ID of the source component or trust zone (required for single item mode)
+            destination_id: ID of the destination component or trust zone (required for single item mode)
             transformation_type: Type of transformation applied to the asset
             controls: List of security controls applied to the flow
             description: Description of the flow
@@ -1058,20 +1082,25 @@ def register_tools(mcp):
             authorized: Whether the flow is authorized
             validated: Whether the flow is validated
             risk_level: Risk level of the flow (1-5)
+            items: Optional list of flow dicts for batch operation
 
         Returns:
-            A confirmation message with the flow ID
+            A confirmation message with the flow ID(s)
         """
-        return await add_flow_impl(
-            ctx, asset_id, source_id, destination_id, transformation_type,
-            controls, description, protocol, encryption, authenticated,
-            authorized, validated, risk_level
+        return await batch_add(
+            ctx, items,
+            {"asset_id": asset_id, "source_id": source_id, "destination_id": destination_id,
+             "transformation_type": transformation_type, "controls": controls,
+             "description": description, "protocol": protocol, "encryption": encryption,
+             "authenticated": authenticated, "authorized": authorized,
+             "validated": validated, "risk_level": risk_level},
+            add_flow_impl, "flow"
         )
     
     @mcp.tool()
     async def update_flow(
         ctx: Context,
-        id: str,
+        id: str = None,
         asset_id: Optional[str] = None,
         source_id: Optional[str] = None,
         destination_id: Optional[str] = None,
@@ -1084,14 +1113,17 @@ def register_tools(mcp):
         authorized: Optional[bool] = None,
         validated: Optional[bool] = None,
         risk_level: Optional[int] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Update an existing asset flow.
+        """Update an existing asset flow. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing asset flow in the system with the specified properties.
+        This tool updates one or more existing asset flows in the system.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of flow dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the flow to update
+            id: ID of the flow to update (required for single item mode)
             asset_id: New ID of the asset being transferred
             source_id: New ID of the source component or trust zone
             destination_id: New ID of the destination component or trust zone
@@ -1104,14 +1136,19 @@ def register_tools(mcp):
             authorized: New authorization status
             validated: New validation status
             risk_level: New risk level of the flow (1-5)
+            items: Optional list of flow dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_flow_impl(
-            ctx, id, asset_id, source_id, destination_id, transformation_type,
-            controls, description, protocol, encryption, authenticated,
-            authorized, validated, risk_level
+        return await batch_update(
+            ctx, items,
+            {"id": id, "asset_id": asset_id, "source_id": source_id,
+             "destination_id": destination_id, "transformation_type": transformation_type,
+             "controls": controls, "description": description, "protocol": protocol,
+             "encryption": encryption, "authenticated": authenticated,
+             "authorized": authorized, "validated": validated, "risk_level": risk_level},
+            update_flow_impl, "flow"
         )
     
     @mcp.tool()
@@ -1155,20 +1192,24 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_flow(
         ctx: Context,
-        id: str,
+        id: Optional[str] = None,
+        ids: Optional[List[str]] = None,
     ) -> str:
-        """Delete an asset flow from the system.
+        """Delete an asset flow from the system. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes an asset flow from the system.
+        This tool deletes one or more asset flows from the system.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the flow to delete
+            id: ID of the flow to delete (required for single item mode)
+            ids: Optional list of flow IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_flow_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_flow_impl, "flow")
     
     @mcp.tool()
     async def get_asset_flow_analysis_plan(

--- a/threat_modeling_mcp_server/tools/assumption_manager.py
+++ b/threat_modeling_mcp_server/tools/assumption_manager.py
@@ -1,11 +1,12 @@
 """Assumption Manager functionality for the Cline Threat Modeling MCP Server."""
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Any
 from loguru import logger
 from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from threat_modeling_mcp_server.models.models import Assumption
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # In-memory storage for assumptions
@@ -193,27 +194,35 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_assumption(
         ctx: Context,
-        description: str = Field(description="Description of the assumption"),
-        category: str = Field(description="Category of the assumption (e.g., 'Network', 'Authentication', 'AWS Services')"),
-        impact: str = Field(description="Impact of the assumption on the threat model"),
-        rationale: str = Field(description="Rationale for making this assumption"),
+        description: str = Field(default=None, description="Description of the assumption (required for single item mode)"),
+        category: str = Field(default=None, description="Category of the assumption (e.g., 'Network', 'Authentication', 'AWS Services') (required for single item mode)"),
+        impact: str = Field(default=None, description="Impact of the assumption on the threat model (required for single item mode)"),
+        rationale: str = Field(default=None, description="Rationale for making this assumption (required for single item mode)"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of assumptions to add in batch. Each dict should contain 'description', 'category', 'impact', 'rationale'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new assumption to the threat model.
+        """Add a new assumption to the threat model. Supports batch operations via the 'items' parameter.
 
         Assumptions are statements that we accept as true without requiring further validation.
         They help scope the threat model by establishing boundaries and constraints.
+        For single item: provide description, category, impact, rationale directly.
+        For batch: provide a list of assumption dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            description: Description of the assumption
-            category: Category of the assumption (e.g., 'Network', 'Authentication', 'AWS Services')
-            impact: Impact of the assumption on the threat model
-            rationale: Rationale for making this assumption
+            description: Description of the assumption (required for single item mode)
+            category: Category of the assumption (required for single item mode)
+            impact: Impact of the assumption on the threat model (required for single item mode)
+            rationale: Rationale for making this assumption (required for single item mode)
+            items: Optional list of assumption dicts for batch operation
 
         Returns:
-            A confirmation message with the assumption ID
+            A confirmation message with the assumption ID(s)
         """
-        return await add_assumption_impl(ctx, description, category, impact, rationale)
+        return await batch_add(
+            ctx, items,
+            {"description": description, "category": category, "impact": impact, "rationale": rationale},
+            add_assumption_impl, "assumption"
+        )
 
     @mcp.tool()
     async def list_assumptions(
@@ -250,39 +259,53 @@ def register_tools(mcp):
     @mcp.tool()
     async def update_assumption(
         ctx: Context,
-        id: str = Field(description="ID of the assumption to update"),
+        id: str = Field(default=None, description="ID of the assumption to update (required for single item mode)"),
         description: Optional[str] = Field(default=None, description="New description of the assumption"),
         category: Optional[str] = Field(default=None, description="New category of the assumption"),
         impact: Optional[str] = Field(default=None, description="New impact of the assumption"),
         rationale: Optional[str] = Field(default=None, description="New rationale for the assumption"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of assumptions to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing assumption.
+        """Update an existing assumption. Supports batch operations via the 'items' parameter.
+
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of assumption dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the assumption to update
+            id: ID of the assumption to update (required for single item mode)
             description: New description of the assumption
             category: New category of the assumption
             impact: New impact of the assumption
             rationale: New rationale for the assumption
+            items: Optional list of assumption dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_assumption_impl(ctx, id, description, category, impact, rationale)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "description": description, "category": category, "impact": impact, "rationale": rationale},
+            update_assumption_impl, "assumption"
+        )
 
     @mcp.tool()
     async def delete_assumption(
         ctx: Context,
-        id: str = Field(description="ID of the assumption to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the assumption to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of assumption IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete an assumption from the threat model.
+        """Delete an assumption from the threat model. Supports batch operations via the 'ids' parameter.
+
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the assumption to delete
+            id: ID of the assumption to delete (required for single item mode)
+            ids: Optional list of assumption IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_assumption_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_assumption_impl, "assumption")

--- a/threat_modeling_mcp_server/tools/threat_actor_analyzer.py
+++ b/threat_modeling_mcp_server/tools/threat_actor_analyzer.py
@@ -9,6 +9,7 @@ from threat_modeling_mcp_server.models.threat_actor_models import (
     ThreatActor, ThreatActorLibrary, ThreatActorType, 
     Motivation, CapabilityLevel, ResourceLevel
 )
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # Global state
@@ -541,41 +542,51 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_threat_actor(
         ctx: Context,
-        name: str = Field(description="Name of the threat actor"),
-        type: str = Field(description="Type of the threat actor (e.g., 'Insider', 'External', 'Nation-state')"),
-        capability_level: str = Field(description="Capability level of the threat actor (Low, Medium, High)"),
-        motivations: List[str] = Field(description="Motivations of the threat actor (e.g., 'Financial', 'Political', 'Espionage')"),
-        resources: str = Field(description="Resources available to the threat actor (Limited, Moderate, Extensive)"),
+        name: str = Field(default=None, description="Name of the threat actor (required for single item mode)"),
+        type: str = Field(default=None, description="Type of the threat actor (e.g., 'Insider', 'External', 'Nation-state') (required for single item mode)"),
+        capability_level: str = Field(default=None, description="Capability level of the threat actor (Low, Medium, High) (required for single item mode)"),
+        motivations: List[str] = Field(default=None, description="Motivations of the threat actor (e.g., 'Financial', 'Political', 'Espionage') (required for single item mode)"),
+        resources: str = Field(default=None, description="Resources available to the threat actor (Limited, Moderate, Extensive) (required for single item mode)"),
         description: Optional[str] = Field(default=None, description="Description of the threat actor"),
         priority: int = Field(default=0, description="Priority of the threat actor (1-10, 0 means not ranked)"),
         relevance_score: float = Field(default=0.5, description="Relevance score of the threat actor (0.0-1.0)"),
         is_relevant: bool = Field(default=True, description="Whether the threat actor is relevant to the system"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of threat actors to add in batch. Each dict should contain 'name', 'type', 'capability_level', 'motivations', 'resources', and optionally other fields. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new threat actor.
+        """Add a new threat actor. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new threat actor to the threat model.
+        This tool adds one or more threat actors to the threat model.
+        For single item: provide name, type, capability_level, motivations, resources directly.
+        For batch: provide a list of threat actor dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the threat actor
-            type: Type of the threat actor (e.g., 'Insider', 'External', 'Nation-state')
-            capability_level: Capability level of the threat actor (Low, Medium, High)
-            motivations: Motivations of the threat actor (e.g., 'Financial', 'Political', 'Espionage')
-            resources: Resources available to the threat actor (Limited, Moderate, Extensive)
+            name: Name of the threat actor (required for single item mode)
+            type: Type of the threat actor (required for single item mode)
+            capability_level: Capability level of the threat actor (required for single item mode)
+            motivations: Motivations of the threat actor (required for single item mode)
+            resources: Resources available to the threat actor (required for single item mode)
             description: Description of the threat actor
             priority: Priority of the threat actor (1-10, 0 means not ranked)
             relevance_score: Relevance score of the threat actor (0.0-1.0)
             is_relevant: Whether the threat actor is relevant to the system
+            items: Optional list of threat actor dicts for batch operation
 
         Returns:
-            A confirmation message with the threat actor ID
+            A confirmation message with the threat actor ID(s)
         """
-        return await add_threat_actor_impl(ctx, name, type, capability_level, motivations, resources, description, priority, relevance_score, is_relevant)
+        return await batch_add(
+            ctx, items,
+            {"name": name, "type": type, "capability_level": capability_level,
+             "motivations": motivations, "resources": resources, "description": description,
+             "priority": priority, "relevance_score": relevance_score, "is_relevant": is_relevant},
+            add_threat_actor_impl, "threat actor"
+        )
 
     @mcp.tool()
     async def update_threat_actor(
         ctx: Context,
-        id: str = Field(description="ID of the threat actor to update"),
+        id: str = Field(default=None, description="ID of the threat actor to update (required for single item mode)"),
         name: Optional[str] = Field(default=None, description="New name of the threat actor"),
         type: Optional[str] = Field(default=None, description="New type of the threat actor"),
         capability_level: Optional[str] = Field(default=None, description="New capability level of the threat actor"),
@@ -585,14 +596,17 @@ def register_tools(mcp):
         priority: Optional[int] = Field(default=None, description="New priority of the threat actor (1-10)"),
         relevance_score: Optional[float] = Field(default=None, description="New relevance score of the threat actor (0.0-1.0)"),
         is_relevant: Optional[bool] = Field(default=None, description="New relevance status of the threat actor"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of threat actors to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing threat actor.
+        """Update an existing threat actor. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing threat actor in the threat model.
+        This tool updates one or more existing threat actors in the threat model.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of threat actor dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the threat actor to update
+            id: ID of the threat actor to update (required for single item mode)
             name: New name of the threat actor
             type: New type of the threat actor
             capability_level: New capability level of the threat actor
@@ -602,11 +616,18 @@ def register_tools(mcp):
             priority: New priority of the threat actor (1-10)
             relevance_score: New relevance score of the threat actor (0.0-1.0)
             is_relevant: New relevance status of the threat actor
+            items: Optional list of threat actor dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_threat_actor_impl(ctx, id, name, type, capability_level, motivations, resources, description, priority, relevance_score, is_relevant)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "type": type, "capability_level": capability_level,
+             "motivations": motivations, "resources": resources, "description": description,
+             "priority": priority, "relevance_score": relevance_score, "is_relevant": is_relevant},
+            update_threat_actor_impl, "threat actor"
+        )
 
     @mcp.tool()
     async def list_threat_actors(
@@ -649,20 +670,24 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_threat_actor(
         ctx: Context,
-        id: str = Field(description="ID of the threat actor to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the threat actor to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of threat actor IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a threat actor.
+        """Delete a threat actor. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a threat actor from the threat model.
+        This tool deletes one or more threat actors from the threat model.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the threat actor to delete
+            id: ID of the threat actor to delete (required for single item mode)
+            ids: Optional list of threat actor IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_threat_actor_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_threat_actor_impl, "threat actor")
 
     @mcp.tool()
     async def set_threat_actor_relevance(

--- a/threat_modeling_mcp_server/tools/threat_generator.py
+++ b/threat_modeling_mcp_server/tools/threat_generator.py
@@ -15,6 +15,7 @@ from threat_modeling_mcp_server.models.threat_models import (
 )
 from threat_modeling_mcp_server.tools.assumption_manager import assumptions
 from threat_modeling_mcp_server.utils.file_utils import normalize_output_path
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # Global dictionaries to store threats and mitigations
@@ -654,41 +655,50 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_threat(
         ctx: Context,
-        threat_source: str,
-        prerequisites: str,
-        threat_action: str,
-        threat_impact: str,
+        threat_source: str = None,
+        prerequisites: str = None,
+        threat_action: str = None,
+        threat_impact: str = None,
         category: Optional[str] = None,
         severity: Optional[str] = None,
         likelihood: Optional[str] = None,
         affected_components: Optional[List[str]] = None,
         affected_assets: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Add a new threat to the model.
+        """Add a new threat to the model. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new threat to the threat model.
+        This tool adds one or more threats to the threat model.
         IMPORTANT: Each text field must be 200 characters or fewer to comply with the Threat Composer schema.
+        For single item: provide threat_source, prerequisites, threat_action, threat_impact directly.
+        For batch: provide a list of threat dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            threat_source: Source of the threat, max 200 chars (e.g., 'external attacker')
-            prerequisites: Prerequisites for the threat, max 200 chars (e.g., 'with access to the network')
-            threat_action: Action performed by the threat, max 200 chars (e.g., 'intercept unencrypted data')
-            threat_impact: Impact of the threat, max 200 chars (e.g., 'exposure of sensitive data')
+            threat_source: Source of the threat, max 200 chars (required for single item mode)
+            prerequisites: Prerequisites for the threat, max 200 chars (required for single item mode)
+            threat_action: Action performed by the threat, max 200 chars (required for single item mode)
+            threat_impact: Impact of the threat, max 200 chars (required for single item mode)
             category: STRIDE category of the threat
             severity: Severity of the threat
             likelihood: Likelihood of the threat
             affected_components: List of component IDs affected by the threat
             affected_assets: List of asset IDs affected by the threat
             tags: List of tags for the threat
+            items: Optional list of threat dicts for batch operation
 
         Returns:
-            A confirmation message with the threat ID
+            A confirmation message with the threat ID(s)
         """
-        return await add_threat_impl(
-            ctx, threat_source, prerequisites, threat_action, threat_impact,
-            category, severity, likelihood, affected_components, affected_assets, tags
+        return await batch_add(
+            ctx, items,
+            {"threat_source": threat_source, "prerequisites": prerequisites,
+             "threat_action": threat_action, "threat_impact": threat_impact,
+             "category": category, "severity": severity, "likelihood": likelihood,
+             "affected_components": affected_components, "affected_assets": affected_assets,
+             "tags": tags},
+            add_threat_impl, "threat"
         )
     
     @mcp.tool()
@@ -734,7 +744,7 @@ def register_tools(mcp):
     @mcp.tool()
     async def update_threat(
         ctx: Context,
-        id: str,
+        id: str = None,
         threat_source: Optional[str] = None,
         prerequisites: Optional[str] = None,
         threat_action: Optional[str] = None,
@@ -746,15 +756,18 @@ def register_tools(mcp):
         affected_components: Optional[List[str]] = None,
         affected_assets: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Update an existing threat.
+        """Update an existing threat. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing threat in the threat model.
+        This tool updates one or more existing threats in the threat model.
         IMPORTANT: Each text field must be 200 characters or fewer to comply with the Threat Composer schema.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of threat dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the threat to update
+            id: ID of the threat to update (required for single item mode)
             threat_source: New source of the threat, max 200 chars
             prerequisites: New prerequisites for the threat, max 200 chars
             threat_action: New action performed by the threat, max 200 chars
@@ -766,63 +779,81 @@ def register_tools(mcp):
             affected_components: New list of component IDs affected by the threat
             affected_assets: New list of asset IDs affected by the threat
             tags: New list of tags for the threat
+            items: Optional list of threat dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_threat_impl(
-            ctx, id, threat_source, prerequisites, threat_action, threat_impact,
-            category, severity, likelihood, status, affected_components, affected_assets, tags
+        return await batch_update(
+            ctx, items,
+            {"id": id, "threat_source": threat_source, "prerequisites": prerequisites,
+             "threat_action": threat_action, "threat_impact": threat_impact,
+             "category": category, "severity": severity, "likelihood": likelihood,
+             "status": status, "affected_components": affected_components,
+             "affected_assets": affected_assets, "tags": tags},
+            update_threat_impl, "threat"
         )
     
     @mcp.tool()
     async def delete_threat(
         ctx: Context,
-        id: str,
+        id: Optional[str] = None,
+        ids: Optional[List[str]] = None,
     ) -> str:
-        """Delete a threat from the model.
+        """Delete a threat from the model. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a threat from the threat model.
+        This tool deletes one or more threats from the threat model.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the threat to delete
+            id: ID of the threat to delete (required for single item mode)
+            ids: Optional list of threat IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_threat_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_threat_impl, "threat")
     
     @mcp.tool()
     async def add_mitigation(
         ctx: Context,
-        content: str,
+        content: str = None,
         type: Optional[str] = None,
         status: str = "mitigationIdentified",
         implementation_details: Optional[str] = None,
         cost: Optional[str] = None,
         effectiveness: Optional[str] = None,
         metadata: Optional[List[Dict[str, str]]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Add a new mitigation to the model.
+        """Add a new mitigation to the model. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new mitigation to the threat model.
+        This tool adds one or more mitigations to the threat model.
+        For single item: provide content and optional fields directly.
+        For batch: provide a list of mitigation dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            content: Content of the mitigation
+            content: Content of the mitigation (required for single item mode)
             type: Type of the mitigation
             status: Status of the mitigation
             implementation_details: Implementation details of the mitigation
             cost: Cost of the mitigation
             effectiveness: Effectiveness of the mitigation
             metadata: Metadata for the mitigation
+            items: Optional list of mitigation dicts for batch operation
 
         Returns:
-            A confirmation message with the mitigation ID
+            A confirmation message with the mitigation ID(s)
         """
-        return await add_mitigation_impl(
-            ctx, content, type, status, implementation_details, cost, effectiveness, metadata
+        return await batch_add(
+            ctx, items,
+            {"content": content, "type": type, "status": status,
+             "implementation_details": implementation_details, "cost": cost,
+             "effectiveness": effectiveness, "metadata": metadata},
+            add_mitigation_impl, "mitigation"
         )
     
     @mcp.tool()
@@ -866,7 +897,7 @@ def register_tools(mcp):
     @mcp.tool()
     async def update_mitigation(
         ctx: Context,
-        id: str,
+        id: str = None,
         content: Optional[str] = None,
         type: Optional[str] = None,
         status: Optional[str] = None,
@@ -874,14 +905,17 @@ def register_tools(mcp):
         cost: Optional[str] = None,
         effectiveness: Optional[str] = None,
         metadata: Optional[List[Dict[str, str]]] = None,
+        items: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Update an existing mitigation.
+        """Update an existing mitigation. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing mitigation in the threat model.
+        This tool updates one or more existing mitigations in the threat model.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of mitigation dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the mitigation to update
+            id: ID of the mitigation to update (required for single item mode)
             content: New content of the mitigation
             type: New type of the mitigation
             status: New status of the mitigation
@@ -889,29 +923,40 @@ def register_tools(mcp):
             cost: New cost of the mitigation
             effectiveness: New effectiveness of the mitigation
             metadata: New metadata for the mitigation
+            items: Optional list of mitigation dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_mitigation_impl(ctx, id, content, type, status, implementation_details, cost, effectiveness, metadata)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "content": content, "type": type, "status": status,
+             "implementation_details": implementation_details, "cost": cost,
+             "effectiveness": effectiveness, "metadata": metadata},
+            update_mitigation_impl, "mitigation"
+        )
     
     @mcp.tool()
     async def delete_mitigation(
         ctx: Context,
-        id: str,
+        id: Optional[str] = None,
+        ids: Optional[List[str]] = None,
     ) -> str:
-        """Delete a mitigation from the model.
+        """Delete a mitigation from the model. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a mitigation from the threat model.
+        This tool deletes one or more mitigations from the threat model.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the mitigation to delete
+            id: ID of the mitigation to delete (required for single item mode)
+            ids: Optional list of mitigation IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_mitigation_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_mitigation_impl, "mitigation")
     
     @mcp.tool()
     async def link_mitigation_to_threat(

--- a/threat_modeling_mcp_server/tools/trust_boundary_analyzer.py
+++ b/threat_modeling_mcp_server/tools/trust_boundary_analyzer.py
@@ -10,6 +10,7 @@ from threat_modeling_mcp_server.models.trust_boundary_models import (
     BoundaryType, AuthenticationMethod, AuthorizationMethod, TrustLevel
 )
 from threat_modeling_mcp_server.models.architecture_models import Component, Connection
+from threat_modeling_mcp_server.utils.batch_utils import batch_add, batch_update, batch_delete
 
 
 # Global state
@@ -1299,48 +1300,64 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_trust_zone(
         ctx: Context,
-        name: str = Field(description="Name of the trust zone"),
-        trust_level: str = Field(description="Trust level of the zone"),
+        name: str = Field(default=None, description="Name of the trust zone (required for single item mode)"),
+        trust_level: str = Field(default=None, description="Trust level of the zone (required for single item mode)"),
         description: Optional[str] = Field(default=None, description="Description of the trust zone"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of trust zones to add in batch. Each dict should contain 'name', 'trust_level', and optionally 'description'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new trust zone.
+        """Add a new trust zone. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new trust zone to the system architecture.
+        This tool adds one or more trust zones to the system architecture.
+        For single item: provide name, trust_level, and optional fields directly.
+        For batch: provide a list of trust zone dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the trust zone
-            trust_level: Trust level of the zone
+            name: Name of the trust zone (required for single item mode)
+            trust_level: Trust level of the zone (required for single item mode)
             description: Description of the trust zone
+            items: Optional list of trust zone dicts for batch operation
 
         Returns:
-            A confirmation message with the trust zone ID
+            A confirmation message with the trust zone ID(s)
         """
-        return await add_trust_zone_impl(ctx, name, trust_level, description)
+        return await batch_add(
+            ctx, items,
+            {"name": name, "trust_level": trust_level, "description": description},
+            add_trust_zone_impl, "trust zone"
+        )
 
     @mcp.tool()
     async def update_trust_zone(
         ctx: Context,
-        id: str = Field(description="ID of the trust zone to update"),
+        id: str = Field(default=None, description="ID of the trust zone to update (required for single item mode)"),
         name: Optional[str] = Field(default=None, description="New name of the trust zone"),
         trust_level: Optional[str] = Field(default=None, description="New trust level of the zone"),
         description: Optional[str] = Field(default=None, description="New description of the trust zone"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of trust zones to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing trust zone.
+        """Update an existing trust zone. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing trust zone in the system architecture.
+        This tool updates one or more existing trust zones in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of trust zone dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the trust zone to update
+            id: ID of the trust zone to update (required for single item mode)
             name: New name of the trust zone
             trust_level: New trust level of the zone
             description: New description of the trust zone
+            items: Optional list of trust zone dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_trust_zone_impl(ctx, id, name, trust_level, description)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "trust_level": trust_level, "description": description},
+            update_trust_zone_impl, "trust zone"
+        )
 
     @mcp.tool()
     async def list_trust_zones(
@@ -1381,40 +1398,52 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_trust_zone(
         ctx: Context,
-        id: str = Field(description="ID of the trust zone to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the trust zone to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of trust zone IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a trust zone.
+        """Delete a trust zone. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a trust zone from the system architecture.
+        This tool deletes one or more trust zones from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the trust zone to delete
+            id: ID of the trust zone to delete (required for single item mode)
+            ids: Optional list of trust zone IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_trust_zone_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_trust_zone_impl, "trust zone")
 
     @mcp.tool()
     async def add_component_to_zone(
         ctx: Context,
-        zone_id: str = Field(description="ID of the trust zone"),
-        component_id: str = Field(description="ID of the component to add"),
+        zone_id: str = Field(default=None, description="ID of the trust zone (required for single item mode)"),
+        component_id: str = Field(default=None, description="ID of the component to add (required for single item mode)"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of zone-component pairs to add in batch. Each dict should contain 'zone_id' and 'component_id'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a component to a trust zone.
+        """Add a component to a trust zone. Supports batch operations via the 'items' parameter.
 
-        This tool adds a component to a trust zone in the system architecture.
+        This tool adds one or more components to trust zones in the system architecture.
+        For single item: provide zone_id and component_id directly.
+        For batch: provide a list of dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            zone_id: ID of the trust zone
-            component_id: ID of the component to add
+            zone_id: ID of the trust zone (required for single item mode)
+            component_id: ID of the component to add (required for single item mode)
+            items: Optional list of zone-component pair dicts for batch operation
 
         Returns:
             A confirmation message
         """
-        return await add_component_to_zone_impl(ctx, zone_id, component_id)
+        return await batch_add(
+            ctx, items,
+            {"zone_id": zone_id, "component_id": component_id},
+            add_component_to_zone_impl, "component-to-zone assignment"
+        )
 
     @mcp.tool()
     async def remove_component_from_zone(
@@ -1440,56 +1469,76 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_crossing_point(
         ctx: Context,
-        source_zone_id: str = Field(description="ID of the source trust zone"),
-        destination_zone_id: str = Field(description="ID of the destination trust zone"),
+        source_zone_id: str = Field(default=None, description="ID of the source trust zone (required for single item mode)"),
+        destination_zone_id: str = Field(default=None, description="ID of the destination trust zone (required for single item mode)"),
         authentication_method: Optional[str] = Field(default=None, description="Authentication method used at the crossing point"),
         authorization_method: Optional[str] = Field(default=None, description="Authorization method used at the crossing point"),
         description: Optional[str] = Field(default=None, description="Description of the crossing point"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of crossing points to add in batch. Each dict should contain 'source_zone_id', 'destination_zone_id', and optionally 'authentication_method', 'authorization_method', 'description'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new crossing point.
+        """Add a new crossing point. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new crossing point between trust zones in the system architecture.
+        This tool adds one or more crossing points between trust zones in the system architecture.
+        For single item: provide source_zone_id, destination_zone_id, and optional fields directly.
+        For batch: provide a list of crossing point dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            source_zone_id: ID of the source trust zone
-            destination_zone_id: ID of the destination trust zone
+            source_zone_id: ID of the source trust zone (required for single item mode)
+            destination_zone_id: ID of the destination trust zone (required for single item mode)
             authentication_method: Authentication method used at the crossing point
             authorization_method: Authorization method used at the crossing point
             description: Description of the crossing point
+            items: Optional list of crossing point dicts for batch operation
 
         Returns:
-            A confirmation message with the crossing point ID
+            A confirmation message with the crossing point ID(s)
         """
-        return await add_crossing_point_impl(ctx, source_zone_id, destination_zone_id, authentication_method, authorization_method, description)
+        return await batch_add(
+            ctx, items,
+            {"source_zone_id": source_zone_id, "destination_zone_id": destination_zone_id,
+             "authentication_method": authentication_method, "authorization_method": authorization_method,
+             "description": description},
+            add_crossing_point_impl, "crossing point"
+        )
 
     @mcp.tool()
     async def update_crossing_point(
         ctx: Context,
-        id: str = Field(description="ID of the crossing point to update"),
+        id: str = Field(default=None, description="ID of the crossing point to update (required for single item mode)"),
         source_zone_id: Optional[str] = Field(default=None, description="New ID of the source trust zone"),
         destination_zone_id: Optional[str] = Field(default=None, description="New ID of the destination trust zone"),
         authentication_method: Optional[str] = Field(default=None, description="New authentication method"),
         authorization_method: Optional[str] = Field(default=None, description="New authorization method"),
         description: Optional[str] = Field(default=None, description="New description of the crossing point"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of crossing points to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing crossing point.
+        """Update an existing crossing point. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing crossing point in the system architecture.
+        This tool updates one or more existing crossing points in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of crossing point dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the crossing point to update
+            id: ID of the crossing point to update (required for single item mode)
             source_zone_id: New ID of the source trust zone
             destination_zone_id: New ID of the destination trust zone
             authentication_method: New authentication method
             authorization_method: New authorization method
             description: New description of the crossing point
+            items: Optional list of crossing point dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_crossing_point_impl(ctx, id, source_zone_id, destination_zone_id, authentication_method, authorization_method, description)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "source_zone_id": source_zone_id, "destination_zone_id": destination_zone_id,
+             "authentication_method": authentication_method, "authorization_method": authorization_method,
+             "description": description},
+            update_crossing_point_impl, "crossing point"
+        )
 
     @mcp.tool()
     async def list_crossing_points(
@@ -1530,40 +1579,52 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_crossing_point(
         ctx: Context,
-        id: str = Field(description="ID of the crossing point to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the crossing point to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of crossing point IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a crossing point.
+        """Delete a crossing point. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a crossing point from the system architecture.
+        This tool deletes one or more crossing points from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the crossing point to delete
+            id: ID of the crossing point to delete (required for single item mode)
+            ids: Optional list of crossing point IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_crossing_point_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_crossing_point_impl, "crossing point")
 
     @mcp.tool()
     async def add_conn_to_crossing(
         ctx: Context,
-        crossing_point_id: str = Field(description="ID of the crossing point"),
-        connection_id: str = Field(description="ID of the connection to add"),
+        crossing_point_id: str = Field(default=None, description="ID of the crossing point (required for single item mode)"),
+        connection_id: str = Field(default=None, description="ID of the connection to add (required for single item mode)"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of crossing-point-connection pairs to add in batch. Each dict should contain 'crossing_point_id' and 'connection_id'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a connection to a crossing point.
+        """Add a connection to a crossing point. Supports batch operations via the 'items' parameter.
 
-        This tool adds a connection to a crossing point in the system architecture.
+        This tool adds one or more connections to crossing points in the system architecture.
+        For single item: provide crossing_point_id and connection_id directly.
+        For batch: provide a list of dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            crossing_point_id: ID of the crossing point
-            connection_id: ID of the connection to add
+            crossing_point_id: ID of the crossing point (required for single item mode)
+            connection_id: ID of the connection to add (required for single item mode)
+            items: Optional list of crossing-point-connection pair dicts for batch operation
 
         Returns:
             A confirmation message
         """
-        return await add_connection_to_crossing_point_impl(ctx, crossing_point_id, connection_id)
+        return await batch_add(
+            ctx, items,
+            {"crossing_point_id": crossing_point_id, "connection_id": connection_id},
+            add_connection_to_crossing_point_impl, "connection-to-crossing-point assignment"
+        )
 
     @mcp.tool()
     async def remove_conn_from_crossing(
@@ -1589,56 +1650,74 @@ def register_tools(mcp):
     @mcp.tool()
     async def add_trust_boundary(
         ctx: Context,
-        name: str = Field(description="Name of the trust boundary"),
-        type: str = Field(description="Type of the trust boundary"),
+        name: str = Field(default=None, description="Name of the trust boundary (required for single item mode)"),
+        type: str = Field(default=None, description="Type of the trust boundary (required for single item mode)"),
         crossing_point_ids: List[str] = Field(default=[], description="IDs of crossing points that cross this boundary"),
         controls: List[str] = Field(default=[], description="Security controls implemented at this boundary"),
         description: Optional[str] = Field(default=None, description="Description of the trust boundary"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of trust boundaries to add in batch. Each dict should contain 'name', 'type', and optionally 'crossing_point_ids', 'controls', 'description'. When provided, individual parameters are ignored."),
     ) -> str:
-        """Add a new trust boundary.
+        """Add a new trust boundary. Supports batch operations via the 'items' parameter.
 
-        This tool adds a new trust boundary to the system architecture.
+        This tool adds one or more trust boundaries to the system architecture.
+        For single item: provide name, type, and optional fields directly.
+        For batch: provide a list of trust boundary dicts in the 'items' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            name: Name of the trust boundary
-            type: Type of the trust boundary
+            name: Name of the trust boundary (required for single item mode)
+            type: Type of the trust boundary (required for single item mode)
             crossing_point_ids: IDs of crossing points that cross this boundary
             controls: Security controls implemented at this boundary
             description: Description of the trust boundary
+            items: Optional list of trust boundary dicts for batch operation
 
         Returns:
-            A confirmation message with the trust boundary ID
+            A confirmation message with the trust boundary ID(s)
         """
-        return await add_trust_boundary_impl(ctx, name, type, crossing_point_ids, controls, description)
+        return await batch_add(
+            ctx, items,
+            {"name": name, "type": type, "crossing_point_ids": crossing_point_ids,
+             "controls": controls, "description": description},
+            add_trust_boundary_impl, "trust boundary"
+        )
 
     @mcp.tool()
     async def update_trust_boundary(
         ctx: Context,
-        id: str = Field(description="ID of the trust boundary to update"),
+        id: str = Field(default=None, description="ID of the trust boundary to update (required for single item mode)"),
         name: Optional[str] = Field(default=None, description="New name of the trust boundary"),
         type: Optional[str] = Field(default=None, description="New type of the trust boundary"),
         crossing_point_ids: Optional[List[str]] = Field(default=None, description="New IDs of crossing points"),
         controls: Optional[List[str]] = Field(default=None, description="New security controls"),
         description: Optional[str] = Field(default=None, description="New description of the trust boundary"),
+        items: Optional[List[Dict[str, Any]]] = Field(default=None, description="Optional list of trust boundaries to update in batch. Each dict must contain 'id' and any fields to update. When provided, individual parameters are ignored."),
     ) -> str:
-        """Update an existing trust boundary.
+        """Update an existing trust boundary. Supports batch operations via the 'items' parameter.
 
-        This tool updates an existing trust boundary in the system architecture.
+        This tool updates one or more existing trust boundaries in the system architecture.
+        For single item: provide id and fields to update directly.
+        For batch: provide a list of trust boundary dicts in the 'items' parameter (each must include 'id').
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the trust boundary to update
+            id: ID of the trust boundary to update (required for single item mode)
             name: New name of the trust boundary
             type: New type of the trust boundary
             crossing_point_ids: New IDs of crossing points
             controls: New security controls
             description: New description of the trust boundary
+            items: Optional list of trust boundary dicts for batch update
 
         Returns:
             A confirmation message
         """
-        return await update_trust_boundary_impl(ctx, id, name, type, crossing_point_ids, controls, description)
+        return await batch_update(
+            ctx, items,
+            {"id": id, "name": name, "type": type, "crossing_point_ids": crossing_point_ids,
+             "controls": controls, "description": description},
+            update_trust_boundary_impl, "trust boundary"
+        )
 
     @mcp.tool()
     async def list_trust_boundaries(
@@ -1679,20 +1758,24 @@ def register_tools(mcp):
     @mcp.tool()
     async def delete_trust_boundary(
         ctx: Context,
-        id: str = Field(description="ID of the trust boundary to delete"),
+        id: Optional[str] = Field(default=None, description="ID of the trust boundary to delete (required for single item mode)"),
+        ids: Optional[List[str]] = Field(default=None, description="Optional list of trust boundary IDs to delete in batch. When provided, the 'id' parameter is ignored."),
     ) -> str:
-        """Delete a trust boundary.
+        """Delete a trust boundary. Supports batch operations via the 'ids' parameter.
 
-        This tool deletes a trust boundary from the system architecture.
+        This tool deletes one or more trust boundaries from the system architecture.
+        For single item: provide the id directly.
+        For batch: provide a list of IDs in the 'ids' parameter.
 
         Args:
             ctx: MCP context for logging and error handling
-            id: ID of the trust boundary to delete
+            id: ID of the trust boundary to delete (required for single item mode)
+            ids: Optional list of trust boundary IDs for batch deletion
 
         Returns:
             A confirmation message
         """
-        return await delete_trust_boundary_impl(ctx, id)
+        return await batch_delete(ctx, ids, id, delete_trust_boundary_impl, "trust boundary")
 
     @mcp.tool()
     async def get_trust_boundary_analysis_plan(

--- a/threat_modeling_mcp_server/utils/batch_utils.py
+++ b/threat_modeling_mcp_server/utils/batch_utils.py
@@ -1,0 +1,174 @@
+"""Batch operation utilities for the Threat Modeling MCP Server.
+
+This module provides helper functions for batch operations across all tools.
+Batch operations allow multiple items to be added, updated, or deleted in a single
+tool call while maintaining backwards compatibility with single-item operations.
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+from loguru import logger
+
+
+async def batch_add(
+    ctx: Any,
+    items: Optional[List[Dict[str, Any]]],
+    single_item_kwargs: Dict[str, Any],
+    impl_fn: Callable,
+    entity_name: str,
+) -> str:
+    """Handle batch or single add operations.
+    
+    If `items` is provided, iterates over the list and calls impl_fn for each item.
+    Otherwise, calls impl_fn with the single_item_kwargs (original single-item behavior).
+    
+    Args:
+        ctx: MCP context
+        items: Optional list of dicts, each containing the fields for one item
+        single_item_kwargs: The individual field parameters (used when items is None)
+        impl_fn: The implementation function to call for each item
+        entity_name: Name of the entity type for logging (e.g., "component")
+        
+    Returns:
+        A confirmation message (single result or batch summary)
+    """
+    if items is not None:
+        if not items:
+            return f"No {entity_name}s provided in batch."
+        
+        logger.debug(f'Batch adding {len(items)} {entity_name}(s)')
+        results = []
+        errors = []
+        
+        for i, item in enumerate(items):
+            try:
+                result = await impl_fn(ctx, **item)
+                results.append(result)
+            except Exception as e:
+                errors.append(f"Item {i + 1}: {str(e)}")
+        
+        # Build summary
+        summary_parts = []
+        if results:
+            summary_parts.append(f"Successfully added {len(results)} {entity_name}(s):")
+            for r in results:
+                summary_parts.append(f"  - {r}")
+        if errors:
+            summary_parts.append(f"\nFailed to add {len(errors)} {entity_name}(s):")
+            for e in errors:
+                summary_parts.append(f"  - {e}")
+        
+        return "\n".join(summary_parts)
+    else:
+        # Single item mode - original behavior
+        return await impl_fn(ctx, **single_item_kwargs)
+
+
+async def batch_update(
+    ctx: Any,
+    items: Optional[List[Dict[str, Any]]],
+    single_item_kwargs: Dict[str, Any],
+    impl_fn: Callable,
+    entity_name: str,
+) -> str:
+    """Handle batch or single update operations.
+    
+    If `items` is provided, iterates over the list and calls impl_fn for each item.
+    Each item in the list must contain an 'id' field.
+    Otherwise, calls impl_fn with the single_item_kwargs (original single-item behavior).
+    
+    Args:
+        ctx: MCP context
+        items: Optional list of dicts, each containing 'id' and fields to update
+        single_item_kwargs: The individual field parameters (used when items is None)
+        impl_fn: The implementation function to call for each item
+        entity_name: Name of the entity type for logging
+        
+    Returns:
+        A confirmation message (single result or batch summary)
+    """
+    if items is not None:
+        if not items:
+            return f"No {entity_name}s provided in batch."
+        
+        logger.debug(f'Batch updating {len(items)} {entity_name}(s)')
+        results = []
+        errors = []
+        
+        for i, item in enumerate(items):
+            try:
+                result = await impl_fn(ctx, **item)
+                results.append(result)
+            except Exception as e:
+                errors.append(f"Item {i + 1}: {str(e)}")
+        
+        # Build summary
+        summary_parts = []
+        if results:
+            summary_parts.append(f"Successfully updated {len(results)} {entity_name}(s):")
+            for r in results:
+                summary_parts.append(f"  - {r}")
+        if errors:
+            summary_parts.append(f"\nFailed to update {len(errors)} {entity_name}(s):")
+            for e in errors:
+                summary_parts.append(f"  - {e}")
+        
+        return "\n".join(summary_parts)
+    else:
+        # Single item mode - original behavior
+        return await impl_fn(ctx, **single_item_kwargs)
+
+
+async def batch_delete(
+    ctx: Any,
+    ids: Optional[List[str]],
+    single_id: Optional[str],
+    impl_fn: Callable,
+    entity_name: str,
+) -> str:
+    """Handle batch or single delete operations.
+    
+    If `ids` is provided, iterates over the list and calls impl_fn for each id.
+    Otherwise, calls impl_fn with the single_id (original single-item behavior).
+    
+    Args:
+        ctx: MCP context
+        ids: Optional list of IDs to delete
+        single_id: The single ID parameter (used when ids is None)
+        impl_fn: The implementation function to call for each id
+        entity_name: Name of the entity type for logging
+        
+    Returns:
+        A confirmation message (single result or batch summary)
+    """
+    if ids is not None:
+        if not ids:
+            return f"No {entity_name} IDs provided in batch."
+        
+        logger.debug(f'Batch deleting {len(ids)} {entity_name}(s)')
+        results = []
+        errors = []
+        
+        for item_id in ids:
+            try:
+                result = await impl_fn(ctx, item_id)
+                results.append(result)
+            except Exception as e:
+                errors.append(f"ID {item_id}: {str(e)}")
+        
+        # Build summary
+        summary_parts = []
+        if results:
+            summary_parts.append(f"Successfully deleted {len(results)} {entity_name}(s):")
+            for r in results:
+                summary_parts.append(f"  - {r}")
+        if errors:
+            summary_parts.append(f"\nFailed to delete {len(errors)} {entity_name}(s):")
+            for e in errors:
+                summary_parts.append(f"  - {e}")
+        
+        return "\n".join(summary_parts)
+    else:
+        # Single item mode - original behavior
+        if single_id is None:
+            return f"No {entity_name} ID provided."
+        return await impl_fn(ctx, single_id)


### PR DESCRIPTION
Add optional items parameter to add/update tools and optional ids parameter to delete tools across all tool modules. This enables batch operations while maintaining full backwards compatibility — existing single-item calls continue to work unchanged.

Affected tools:

architecture_analyzer: components, connections, data stores
threat_actor_analyzer: threat actors
trust_boundary_analyzer: trust zones, crossing points, trust boundaries, component-to-zone assignments, connection-to-crossing-point assignments
asset_flow_analyzer: assets, flows
threat_generator: threats, mitigations
assumption_manager: assumptions
New utility module:

batch_utils.py
: shared batch_add, batch_update, batch_delete helpers
Testing:

19 unit tests (
test_batch_operations.py
)
20-check integration test (
test_batch_integration.py
)
Verified via MCP Inspector end-to-end
All 123 existing tests continue to pass
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.