### PR TITLE
Fix missing ctx argument error in get_current_phase_status tool

### DIFF
--- a/threat_modeling_mcp_server/tools/step_orchestrator.py
+++ b/threat_modeling_mcp_server/tools/step_orchestrator.py
@@ -636,7 +636,7 @@ The comprehensive threat model file has been generated in the `.threatmodel` dir
         return error_msg
 
 
-def get_current_phase_status() -> Dict[str, Any]:
+def _compute_current_phase_status() -> Dict[str, Any]:
     """Get the current phase status and completion progress.
     
     Returns:
@@ -903,7 +903,7 @@ After completing Phase 7, proceed to Phase 7.5:
             A dictionary with current phase information and completion percentages
         """
         logger.info("Getting current phase status")
-        return get_current_phase_status()
+        return _compute_current_phase_status()
     
     @mcp.tool()
     async def follow_threat_modeling_plan(ctx: Context, phase: str = None) -> str:


### PR DESCRIPTION
## Problem

The `get_current_phase_status` MCP tool always fails with:

```
get_current_phase_status() missing 1 required positional argument: 'ctx'
```

## Root cause

In `threat_modeling_mcp_server/tools/step_orchestrator.py`, there are two functions named `get_current_phase_status`:

- A module-level helper function (no arguments).
- The `@mcp.tool()`-registered async wrapper, which takes `ctx: Context`.

Because they share the same name, the wrapper's body (`return get_current_phase_status()`) recurses into itself instead of calling the intended helper, and does so without the required `ctx` argument — causing the failure on every invocation.

## Fix

Renamed the internal helper to `_compute_current_phase_status` to remove the name collision, and updated the call site inside the tool wrapper accordingly. The public MCP tool name (`get_current_phase_status`) and its signature are unchanged, so this is not a breaking change for clients.

## Testing

- `python3 -m py_compile` passes on the modified file.
- Verified locally via an MCP client: before the fix, every call to `get_current_phase_status` errored; after the fix, it returns the expected phase status payload.