### PR TITLE
Fix: pin mcp to <2.0.0 to fix ModuleNotFoundError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Model Context Protocol (MCP) server for threat modeling"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.6.0,<2.0.0",
     "pydantic>=2.10.6",
     "loguru>=0.7.0",
 ]


### PR DESCRIPTION
*Issue #, if available:*
MCP server fails with "ModuleNotFoundError: No module named 'mcp.server.fastmcp'".

*Description of changes:*
mcp[cli]>=1.6.0 resolved to mcp 2.0.0, which renamed FastMCP to MCPServer and moved it from mcp.server.fastmcp to mcp.server.mcpserver. The server code still imports FastMCP/Context from the v1.x path, so startup failed with "ModuleNotFoundError: No module named 'mcp.server.fastmcp'".

Constrain the dependency to >=1.6.0,<2.0.0 so it resolves to the latest v1.x release (1.29.0) until the code is migrated to the v2 API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
