### PR TITLE
Use .tc.json extension for Threat Composer threat model exports

### DIFF
--- a/.kiro/skills/phase-9-output-generation/SKILL.md
+++ b/.kiro/skills/phase-9-output-generation/SKILL.md
@@ -19,7 +19,7 @@ Generate final deliverables: Threat Composer-compatible JSON export and human-re
 ### export_comprehensive_threat_model(output_path)
 Manual export with custom filename.
 - `output_path`: Base filename (extensions added automatically)
-- Generates BOTH `.json` and `.md` files
+- Generates BOTH `.tc.json` and `.md` files
 - JSON is Threat Composer compatible (schema version 1)
 
 ### export_threat_model_with_remediation_status(output_path)
@@ -33,7 +33,7 @@ Export including code validation results (use after Phase 7.5).
 
 ### JSON Export (Threat Composer Compatible)
 ```
-.threatmodel/comprehensive_threat_model_YYYYMMDD_HHMMSS.json
+.threatmodel/comprehensive_threat_model_YYYYMMDD_HHMMSS.tc.json
 ```
 
 **Schema** (version 1):
@@ -89,7 +89,7 @@ Contains:
 ## Importing to AWS Threat Composer
 1. Open AWS Threat Composer
 2. Click Import
-3. Select the `.json` file from `.threatmodel/`
+3. Select the `.tc.json` file from `.threatmodel/`
 4. All threats, mitigations, assumptions, and links will load
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Running it on a subfolder will limit the scope of threat model and code to that 
 "Add a mitigation for input validation"
 
 # Export results
-"Export the threat model to my_model.json"
+"Export the threat model to my_model.tc.json"
 ```
 
 ## Key Features

--- a/tests/test_comprehensive_exporter.py
+++ b/tests/test_comprehensive_exporter.py
@@ -1,0 +1,108 @@
+"""Unit tests for the comprehensive exporter module."""
+
+import json
+
+import pytest
+
+from threat_modeling_mcp_server.utils.comprehensive_exporter import (
+    export_comprehensive_threat_model,
+)
+
+
+@pytest.fixture
+def export_dir(tmp_path):
+    """Return the .threatmodel directory the exporter writes into."""
+    return tmp_path / ".threatmodel"
+
+
+class TestExportFilenames:
+    """Tests for the filenames produced by export_comprehensive_threat_model."""
+
+    @pytest.mark.parametrize(
+        "output_path",
+        [
+            "my_model",
+            "my_model.json",
+            "my_model.tc.json",
+        ],
+    )
+    def test_json_export_uses_tc_json_extension(self, tmp_path, export_dir, output_path):
+        """Test that the JSON export is written as <name>.tc.json."""
+        export_comprehensive_threat_model(str(tmp_path / output_path))
+
+        assert (export_dir / "my_model.tc.json").is_file()
+
+    @pytest.mark.parametrize(
+        "output_path",
+        [
+            "my_model",
+            "my_model.json",
+            "my_model.tc.json",
+        ],
+    )
+    def test_markdown_export_uses_md_extension(self, tmp_path, export_dir, output_path):
+        """Test that the Markdown export is written as <name>.md."""
+        export_comprehensive_threat_model(str(tmp_path / output_path))
+
+        assert (export_dir / "my_model.md").is_file()
+
+    def test_tc_json_input_does_not_double_the_extension(self, tmp_path, export_dir):
+        """Test that a .tc.json output_path does not produce .tc.tc.json."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model.tc.json"))
+
+        assert not (export_dir / "my_model.tc.tc.json").exists()
+        assert not (export_dir / "my_model.tc.md").exists()
+
+    def test_plain_json_file_is_not_created(self, tmp_path, export_dir):
+        """Test that the export no longer writes a plain <name>.json file."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model.json"))
+
+        assert not (export_dir / "my_model.json").exists()
+
+    def test_exports_only_the_two_expected_files(self, tmp_path, export_dir):
+        """Test that exactly the .tc.json and .md files are written."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model"))
+
+        assert sorted(p.name for p in export_dir.iterdir()) == [
+            "my_model.md",
+            "my_model.tc.json",
+        ]
+
+
+class TestExportContent:
+    """Tests for the content of the exported Threat Composer JSON."""
+
+    def test_json_export_is_valid_json(self, tmp_path, export_dir):
+        """Test that the exported .tc.json file contains valid JSON."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model"))
+
+        with open(export_dir / "my_model.tc.json", encoding="utf-8") as f:
+            assert isinstance(json.load(f), dict)
+
+    def test_json_export_is_threat_composer_schema_1(self, tmp_path, export_dir):
+        """Test that the exported JSON declares Threat Composer schema version 1."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model"))
+
+        with open(export_dir / "my_model.tc.json", encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert data["schema"] == 1
+
+    def test_json_export_contains_threat_composer_fields(self, tmp_path, export_dir):
+        """Test that the exported JSON contains the standard Threat Composer fields."""
+        export_comprehensive_threat_model(str(tmp_path / "my_model"))
+
+        with open(export_dir / "my_model.tc.json", encoding="utf-8") as f:
+            data = json.load(f)
+
+        for field in [
+            "applicationInfo",
+            "architecture",
+            "dataflow",
+            "assumptions",
+            "mitigations",
+            "assumptionLinks",
+            "mitigationLinks",
+            "threats",
+        ]:
+            assert field in data

--- a/threat_modeling_mcp_server/utils/comprehensive_exporter.py
+++ b/threat_modeling_mcp_server/utils/comprehensive_exporter.py
@@ -308,13 +308,18 @@ def export_comprehensive_threat_model(output_path: str, include_extended_data: b
     # Remove any existing extension to create base path
     base_path = os.path.splitext(normalized_path)[0]
     
+    # Strip a trailing ".tc" so a caller-supplied ".tc.json" path does not
+    # produce ".tc.tc.json"
+    if base_path.endswith('.tc'):
+        base_path = base_path[:-len('.tc')]
+    
     # Create the .threatmodel directory if it doesn't exist
     threatmodel_dir = os.path.join(os.path.dirname(base_path), '.threatmodel')
     os.makedirs(threatmodel_dir, exist_ok=True)
     
     # Create paths for both formats
     base_filename = os.path.basename(base_path)
-    json_path = os.path.join(threatmodel_dir, f"{base_filename}.json")
+    json_path = os.path.join(threatmodel_dir, f"{base_filename}.tc.json")
     markdown_path = os.path.join(threatmodel_dir, f"{base_filename}.md")
     
     # Export JSON format


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Threat model exports now write <name>.tc.json instead of <name>.json. The
.tc.json suffix marks the file as Threat Composer content, so it is
distinguishable from the other JSON files that sit alongside it in a project and
from the extended (non-Threat-Composer) export.

The Markdown report filename and the JSON payload are unchanged, so previously
exported files still import into Threat Composer.

Also strips a trailing `.tc` from the base path, since `os.path.splitext` removes
only `.json` and an `output_path` of `my_model.tc.json` would otherwise be
written as `my_model.tc.tc.json`. Docs updated to match, and adds
`tests/test_comprehensive_exporter.py` covering the export filenames.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
